### PR TITLE
Add DVC raw data tracking (raw.dvc)

### DIFF
--- a/data/raw/raw.dvc
+++ b/data/raw/raw.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 26a595de8c32cce09174f0d91250f56b.dir
+  size: 1354953156
+  nfiles: 5
+  hash: md5
+  path: raw


### PR DESCRIPTION
This commit adds DVC tracking for the raw dataset.

- Added data/raw/raw.dvc
- Replaced placeholder .gitkeep
- Raw data is now tracked via DVC instead of Git